### PR TITLE
Singularity container for easy install

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
     - [Compile and upload your application](#compile-and-upload-your-application)
     - [Upload a empty or faulty robot](#upload-a-empty-or-faulty-robot)
     - [Memory map](#memory-map)
+    - [Install on Linux distribution other than Ubuntu](#singularity)
   - [IR Remote](#ir-remote)
     - [Hardware](#hardware-1)
     - [Software](#software-1)
@@ -401,6 +402,58 @@ This table shows addresses in flash memory. The flash memory itself is mapped in
 | 0x20000          | Size of pogobios (usually <64KB) | 0x20000   | Pogobios         |
 | 0x40000          | 0x1969a                          | 0x20000   | User gateware    |
 | 0x60000          | Size of user code                | 0x20000   | User software    |
+
+
+### Install on Linux distribution other than Ubuntu
+
+It is possible to build a [Singularity](https://docs.sylabs.io/guides/3.0/user-guide/index.html) image based on Ubuntu 20.04, which could then be used on any Linux distribution.
+It may also be used to compile and install the sdk (including dependencies) if you have difficulties following the normal install procedure.
+
+First, you need to install Singularity.
+On Debian/Ubuntu distributions:
+```bash
+apt-get install -y singularity-container
+```
+On other distributions, follow the procedure from [the official documentation](https://docs.sylabs.io/guides/3.0/user-guide/installation.html).
+
+After that, you will need to either download an already compiled pogosdk image, or build it yourself.
+To download an already compiled image:
+```bash
+cd pogobot
+singularity pull library://leo.cazenille/pogobot/pogosdk pogosdk.sif
+```
+*Alternative*: to build it yourself:
+```bash
+cd pogobot
+sudo singularity build -F pogosdk.sif pogosdk.def
+```
+This will create a "pogosdk.sif" image file.
+
+Note that the singularity image contains all required applications to use the SDK -- however you'll still need to install SDK dependencies on your local computer, and compile the SDK. In order to do that, use the following commands:
+```bash
+singularity run --app install_dep pogosdk.sif
+singularity run --app compile_sdk pogosdk.sif
+```
+
+You can then test if the compilation of the SDK was successful:
+```bash
+singularity run --app test_install pogosdk.sif
+```
+
+To compile the helloworld example:
+```bash
+cd Software/example/helloworld
+singularity run --app make ../../../../pogosdk.sif
+```
+or:
+```bash
+cd Software/example/helloworld
+singularity exec ../../../../pogosdk.sif make clean all
+```
+
+
+
+
 
 ## IR Remote
 To control each robot, two ways are possible: by cable (debug mode) or by IR.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
     - [Compile and upload your application](#compile-and-upload-your-application)
     - [Upload a empty or faulty robot](#upload-a-empty-or-faulty-robot)
     - [Memory map](#memory-map)
-    - [Install on Linux distribution other than Ubuntu](#singularity)
+    - [Install on Linux distributions other than Ubuntu by using Singularity Containers](#singularity)
   - [IR Remote](#ir-remote)
     - [Hardware](#hardware-1)
     - [Software](#software-1)

--- a/README.md
+++ b/README.md
@@ -404,15 +404,20 @@ This table shows addresses in flash memory. The flash memory itself is mapped in
 | 0x60000          | Size of user code                | 0x20000   | User software    |
 
 
-### Install on Linux distribution other than Ubuntu
+### Install on Linux distributions other than Ubuntu by using Singularity Containers
 
-It is possible to build a [Singularity](https://docs.sylabs.io/guides/3.0/user-guide/index.html) image based on Ubuntu 20.04, which could then be used on any Linux distribution.
+It is possible to build a [Singularity](https://docs.sylabs.io/guides/3.0/user-guide/index.html)/[Apptainer](https://apptainer.org/) image based on Ubuntu 20.04, which could then be used on any Linux distribution.
 It may also be used to compile and install the sdk (including dependencies) if you have difficulties following the normal install procedure.
 
 First, you need to install Singularity.
 On Debian/Ubuntu distributions:
 ```bash
-apt-get install -y singularity-container
+sudo apt update
+sudo apt install -y wget lsb-release
+export DISTRIB_NAME=$(lsb_release -c | cut -f 2)
+wget https://github.com/sylabs/singularity/releases/download/v3.10.4/singularity-ce_3.10.4-${DISTRIB_NAME}_amd64.deb 
+# Alternatively, download one of the .deb package available at https://github.com/sylabs/singularity/releases
+sudo apt install -y ./singularity-ce_3.10.4-${DISTRIB_NAME}_amd64.deb
 ```
 On other distributions, follow the procedure from [the official documentation](https://docs.sylabs.io/guides/3.0/user-guide/installation.html).
 
@@ -420,17 +425,18 @@ After that, you will need to either download an already compiled pogosdk image, 
 To download an already compiled image:
 ```bash
 cd pogobot
-singularity pull library://leo.cazenille/pogobot/pogosdk pogosdk.sif
+singularity pull --arch amd64 pogosdk.sif library://leo.cazenille/pogobot/pogosdk:latest
 ```
-*Alternative*: to build it yourself:
+*Alternative*: to build it yourself (can take some time):
 ```bash
 cd pogobot
 sudo singularity build -F pogosdk.sif pogosdk.def
 ```
-This will create a "pogosdk.sif" image file.
+This will create a "pogosdk.sif" image file (size: around 2GB).
 
 Note that the singularity image contains all required applications to use the SDK -- however you'll still need to install SDK dependencies on your local computer, and compile the SDK. In order to do that, use the following commands:
 ```bash
+cd pogobot
 singularity run --app install_dep pogosdk.sif
 singularity run --app compile_sdk pogosdk.sif
 ```

--- a/pogosdk.def
+++ b/pogosdk.def
@@ -1,0 +1,130 @@
+Bootstrap: docker
+From: ubuntu:20.04
+
+
+%labels
+    Author leo.cazenille@gmail.com
+    Version 0.1.0
+
+%environment
+    export LC_ALL=C.UTF-8
+    export LANG=C.UTF-8
+    export PATH=$PATH:/pogobot/dependencies/riscv64-unknown-elf-gcc-10.1.0-2020.08.2-x86_64-linux-ubuntu14/bin
+
+%post
+    export DEBIAN_FRONTEND=noninteractive
+    export NPROC=$(  grep -i "^processor" /proc/cpuinfo | wc -l )
+
+    apt-get update
+    apt-get install -y wget python3 python3-dev python3-pip git
+    apt-get -y install bison build-essential clang clang-format cmake flex gawk git graphviz libboost-all-dev libboost-dev libboost-filesystem-dev libboost-iostreams-dev libboost-program-options-dev libboost-python-dev libboost-system-dev libboost-thread-dev libeigen3-dev libffi-dev libftdi-dev libreadline-dev mercurial pkg-config python3 python3-dev python3-pip python3-setuptools qt5-default tcl-dev xdot zlib1g-dev
+    pip3 install meson==0.64.1 ninja==1.11.1
+
+    cd /
+    git clone https://github.com/nekonaute/pogobot.git
+    cd /pogobot
+    mkdir -p dependencies
+
+    # gcc and toolchain
+    cd dependencies
+    git clone https://github.com/enjoy-digital/litex.git
+    cd litex
+    git checkout 3ab7eaa5f7afb4d432b5641d7761813d3274d25f
+    chmod +x litex_setup.py
+    ./litex_setup.py --dev --gcc riscv
+
+    # icestorm
+    cd /pogobot/dependencies
+    git clone https://github.com/cliffordwolf/icestorm.git icestorm
+    cd icestorm
+    git checkout 2bc541743ada3542c6da36a50e66303b9cbd2059
+    make -j${NPROC} 
+    make install
+
+    # yosys
+    cd /pogobot/dependencies
+    git clone https://github.com/YosysHQ/yosys
+    cd yosys
+    git checkout tags/yosys-0.18
+    make -j${NPROC}
+    make install
+
+    # nextpnr
+    cd /pogobot/dependencies
+    git clone https://github.com/YosysHQ/nextpnr
+    cd nextpnr
+    git checkout 8d063d38b148b1e7095a032ffc9cf957c2407f32
+    cmake . -DARCH=ice40
+    make -j${NPROC}
+    make install
+
+
+
+%runscript
+    echo "Nothing there yet..."
+
+%apprun install_dep
+#    git clone https://github.com/nekonaute/pogobot.git
+#    cd pogobot
+    mkdir -p dependencies
+
+    cd dependencies
+    git clone https://github.com/enjoy-digital/litex.git
+    cd litex
+    git checkout 3ab7eaa5f7afb4d432b5641d7761813d3274d25f
+    chmod +x litex_setup.py
+
+    ./litex_setup.py --dev init
+    ./litex_setup.py --dev install
+    ln -s ../migen
+    cd ..
+    cat ../litex_version.txt | awk '{ if(!system("test -d " $1)) {system("git -C " $1 " checkout " $3)}}'
+
+    # icestorm
+    git clone https://github.com/cliffordwolf/icestorm.git icestorm
+    cd icestorm
+    git checkout 2bc541743ada3542c6da36a50e66303b9cbd2059
+    make -j${NPROC} 
+    cd ..
+
+    # yosys
+    git clone https://github.com/YosysHQ/yosys
+    cd yosys
+    git checkout tags/yosys-0.18
+    make -j${NPROC}
+    cd ..
+
+    # nextpnr
+    git clone https://github.com/YosysHQ/nextpnr
+    cd nextpnr
+    git checkout 8d063d38b148b1e7095a032ffc9cf957c2407f32
+    cmake . -DARCH=ice40
+    make -j${NPROC}
+    cd ..
+
+
+%apprun compile_sdk
+    cd Software
+    ./pogosoc.py --target=pogobotv3 --cpu-variant=lite --build
+    cd sdk
+    make
+
+
+
+%apprun test_install
+    python3 -m litex.soc.integration.soc_core && echo "LITEX: SUCCESS"
+    echo "from migen import *" | python3 && echo "MIGEN: SUCCESS"
+    echo | yosys > /dev/null && echo "YOSYS: SUCCESS"
+    icebox_diff > /dev/null && echo "ICESTORM: SUCCESS"
+    nextpnr-ice40 --version 2> /dev/null && echo "NEXTPNR: SUCCESS"
+    riscv64-unknown-elf-addr2line -v > /dev/null && echo "GCC toolchain: SUCCESS"
+    
+
+%apprun make
+    make clean
+    NPROC=$(  grep -i "^processor" /proc/cpuinfo | wc -l )
+    exec make -j $NPROC
+
+%apprun bash
+    exec bash
+


### PR DESCRIPTION
Hi.
I created a Singularity/apptainer definition file (pogosdk.def) to simplify the installation, esp. on computers that don't have Ubuntu 20.04.
There is a new section in the Readme ("Install on Linux distributions other than Ubuntu by using Singularity Containers") that explains how it can be used to 1) install the sdk on the local computer and 2) compile the helloworld example.